### PR TITLE
Add setup instructions for the 'fish' shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ fi
 export SSH_AUTH_SOCK="/tmp/ssh-agent.${USER}"
 ```
 
+For `fish`, extend `~/.config/fish/config.fish` with the following:
+
+```sh
+if not test -e "/tmp/ssh-agent.$USER"
+    ~/.local/bin/ssh-agent-switcher &> /dev/null &
+    disown &> /dev/null || true
+end
+set -gx SSH_AUTH_SOCK "/tmp/ssh-agent.$USER"
+```
+
 ## Security considerations
 
 ssh-agent-switcher is intended to run under your personal unprivileged account


### PR DESCRIPTION
Since the setup snippet for `bash` & `zsh` doesn't work as-is for `fish`, I thought it might be useful for others to have something that's ready to use.