### PR TITLE
Modernize GitHub Actions versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: actions/cache@v3
+            - uses: actions/cache@v4
               with:
                   path: ~/.cache/bazelisk
                   key: ${{ runner.os }}--${{ hashFiles('**/.bazelversion') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: actions/cache@v3
+            - uses: actions/cache@v4
               with:
                   path: ~/.cache/bazelisk
                   key: ${{ runner.os }}--${{ hashFiles('**/.bazelversion') }}
-            - uses: bazelbuild/setup-bazelisk@v2
+            - uses: bazelbuild/setup-bazelisk@v3
             - run: bazel test --test_output=streamed //:all
 
     go-build:


### PR DESCRIPTION
This fixes 400 errors when accessing the cache from actions.