### PR TITLE
Simplify error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ publish = false  # Not ready for release yet.
 libc = "0.2"
 log = "0.4"
 signal-hook = "0.3"
-thiserror = "2.0"
 
 [dependencies.getoptsargs]
 git = "https://github.com/jmmv/getoptsargs"


### PR DESCRIPTION
Drop the use of thiserror, which was prematurely used during the Rust rewrite, and instead use io::Error in find.rs and a simple String in the top-level functions in lib.rs.